### PR TITLE
Unified getting started

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storyblok/create-demo",
-  "version": "0.0.13",
+  "version": "0.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storyblok/create-demo",
-      "version": "0.0.13",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "@oclif/command": "^1",

--- a/src/clone.js
+++ b/src/clone.js
@@ -16,6 +16,10 @@ module.exports = function (repo, targetPath, opts) {
   if (opts.shallow) {
     args.push('--depth', '1')
   }
+  }
+  if (opts.checkout) {
+    args.push('--branch', opts.checkout)
+  }
 
   args.push('--', repo, targetPath)
 

--- a/src/clone.js
+++ b/src/clone.js
@@ -16,6 +16,8 @@ module.exports = function (repo, targetPath, opts) {
   if (opts.shallow) {
     args.push('--depth', '1')
   }
+  if (opts.submodules) {
+    args.push('--recurse-submodules')
   }
   if (opts.checkout) {
     args.push('--branch', opts.checkout)

--- a/src/frameworks.js
+++ b/src/frameworks.js
@@ -63,11 +63,14 @@ module.exports = [
     name: 'Svelte',
     value: 'sveltekit',
     start: 'dev',
-    token: 'd6IKUtAUDiKyAhpJtrLFcwtt',
+    token: 'W1vLyxT5rQ15jBpANjnv0gtt',
     config: 'src/routes/__layout.svelte',
     bridge: 'src/routes/index.svelte',
-    public: 'public',
-    port: '3000',
+    public: 'static',
+    port: '5173',
+    https: true,
+    submodules: true,
+    branch: 'submodule-sveltekit'
   },
   {
     name: 'Gatsby.js (React)',

--- a/src/frameworks.js
+++ b/src/frameworks.js
@@ -65,7 +65,7 @@ module.exports = [
     start: 'dev',
     token: 'd6IKUtAUDiKyAhpJtrLFcwtt',
     config: 'src/routes/__layout.svelte',
-    bridge: 'src/routes/home.svelte',
+    bridge: 'src/routes/index.svelte',
     public: 'public',
     port: '3000',
   },

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ class CreateStoryblokAppCommand extends Command {
         [frameworkDetails.token]: token,
       })
 
-      const protocol = frameworkDetails.port ? 'https' : 'http';
+      const protocol = frameworkDetails.https ? 'https' : 'http';
       const localhostPath = `${protocol}://localhost:${frameworkDetails.port}`
       const publicPath = `./${folder}/${frameworkDetails.public}`
       createPublicFolder({

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ class CreateStoryblokAppCommand extends Command {
       await clone(gettingStartedRepo, 'temp-started', {
         shallow: true,
         args: '',
-        checkout: 'master',
+        checkout: frameworkDetails.branch ?? 'master',
+        submodules: frameworkDetails.submodules ?? false,
       })
 
       copy(`./temp-started/${framework}`, folder)
@@ -61,7 +62,8 @@ class CreateStoryblokAppCommand extends Command {
         [frameworkDetails.token]: token,
       })
 
-      const localhostPath = `http://localhost:${frameworkDetails.port}`
+      const protocol = frameworkDetails.port ? 'https' : 'http';
+      const localhostPath = `${protocol}://localhost:${frameworkDetails.port}`
       const publicPath = `./${folder}/${frameworkDetails.public}`
       createPublicFolder({
         framework,


### PR DESCRIPTION
- added branch in the framework.js for changing the checkout during clone operation (default master)
- added port for internal npm run dev server (for example sveltekit by default listen to 5173)
- https default false if the framework can easily load https
- submodules default false, if the getting-started repository has submodules
- update public directory for sveltekit (static instead of public)
- update the token for sveltekit, because to use the new official space for ultimate tutorial part 1