### PR TITLE
fix: locally serving Storyblok should not be the default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ class CreateStoryblokAppCommand extends Command {
         chalk.yellow(pathEditing),
       )
       if (!localmode) {
+        log('')
         log(chalkSb('If you\'re not using local mode, you need to setup mkcert to use the visual editor in the app: '))
         log('')
         log(chalkSb('2.a MacOS: '), chalk.yellow('https://www.storyblok.com/faq/setup-dev-server-https-proxy'))

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -50,8 +50,8 @@ module.exports = [
   {
     type: 'confirm',
     name: 'localmode',
-    message: 'Storyblok will be served locally on your localhost instead of app.storyblok.com',
+    message: 'Serve Storyblok locally (to skip https setup, not recommended)',
     prefix: '💻',
-    default: true,
+    default: false,
   },
 ]


### PR DESCRIPTION
This switches the default of serving storyblok